### PR TITLE
Add minimal NixOS configuration with user setup and container managem…

### DIFF
--- a/configuration-minimal.nix
+++ b/configuration-minimal.nix
@@ -1,0 +1,17 @@
+{ config, pkgs, ... }: {
+  imports = [
+    ./hardware-configuration.nix
+    ./modules/overlays.nix
+    ./modules/boot.nix
+    ./modules/networking.nix
+    ./modules/locale.nix
+    ./modules/users/minimal.nix
+    # Elige uno Docker o Podman (como comparten el mismo servicio no se pueden usar ambos):
+    # ./containers/docker.nix
+    ./containers/podman.nix
+  ];
+  system.nixos.label = "Minimal";
+  nix.settings.experimental-features = [ "nix-command" "flakes" ];
+  nixpkgs.config.allowUnfree = true;
+  system.stateVersion = "25.05";
+}

--- a/configuration.nix
+++ b/configuration.nix
@@ -15,8 +15,9 @@
     ./modules/virtualbox.nix
     ./modules/virtualbox-compat.nix
     ./modules/users/unknown.nix
-    ./systems/docker.nix
+    ./containers/docker.nix
   ];
+  system.nixos.label = "Full";
   nix.settings.experimental-features = [ "nix-command" "flakes" ];
   nixpkgs.config.allowUnfree = true;
   system.stateVersion = "25.05";

--- a/containers/docker.nix
+++ b/containers/docker.nix
@@ -2,7 +2,8 @@
   virtualisation.docker.enable = true;
   virtualisation.docker.rootless.enable = true;
 
-  # asegúrate de que podman no tenga dockerCompat
+  # Asegura que podman no esté activo cuando usas docker
   virtualisation.podman.enable = false;
 }
+
 

--- a/containers/podman.nix
+++ b/containers/podman.nix
@@ -1,8 +1,7 @@
-
 { config, pkgs, ... }: {
   virtualisation.docker.enable = false;
 
-environment.systemPackages = with pkgs; [ podman-compose ];
+  environment.systemPackages = with pkgs; [ podman-compose ];
 
   virtualisation.podman = {
     enable = true;
@@ -10,3 +9,5 @@ environment.systemPackages = with pkgs; [ podman-compose ];
     defaultNetwork.settings.dns_enabled = true;
   };
 }
+
+

--- a/modules/boot.nix
+++ b/modules/boot.nix
@@ -1,5 +1,6 @@
 { pkgs, ... }: {
   boot.kernelPackages = pkgs.linuxPackages_latest;
+  boot.loader.systemd-boot.configurationLimit = 5;
   boot.loader.systemd-boot.enable = true;
   boot.loader.efi.canTouchEfiVariables = true;
 }

--- a/modules/users/minimal.nix
+++ b/modules/users/minimal.nix
@@ -1,0 +1,13 @@
+{ pkgs, ... }: {
+  users.users.minimal = {
+    isNormalUser = true;
+    description = "minimal user";
+    extraGroups = [ "wheel" "networkmanager" ];
+    shell = pkgs.nushell;
+    packages = with pkgs; [
+      nushell
+    ];
+  };
+}
+
+


### PR DESCRIPTION
…ent. Introduce configuration-minimal.nix, define a minimal user with specific groups, and set up Docker and Podman containers with appropriate settings. Update boot module to limit systemd-boot configurations.